### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,4 +1,6 @@
 name: C/C++ CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Pankaja-Suganda/Argparser/security/code-scanning/1](https://github.com/Pankaja-Suganda/Argparser/security/code-scanning/1)

The best fix is to explicitly specify the minimal permissions needed for this workflow. Since the shown steps only check out code and perform a CMake build (without uploading artifacts, commenting on issues, or manipulating PRs), only `contents: read` permission is necessary. You should add a `permissions` block at the root level of the workflow file (between `name:` and `on:`) to apply these permissions to all jobs unless overridden. This addition should not affect existing functionality but will reduce the risk of over-privileged tokens in workflow jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
